### PR TITLE
refactor: 重构了项目的POM版本管理，全部统一到根项目中

### DIFF
--- a/agileboot-admin/pom.xml
+++ b/agileboot-admin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agileboot</artifactId>
         <groupId>com.agileboot</groupId>
-        <version>1.0.0</version>
+        <version>${agileboot.version}</version>
     </parent>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>
@@ -49,17 +49,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.1.1.RELEASE</version>
                 <executions>
                     <execution>
                         <goals>

--- a/agileboot-api/pom.xml
+++ b/agileboot-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agileboot</artifactId>
         <groupId>com.agileboot</groupId>
-        <version>1.0.0</version>
+        <version>${agileboot.version}</version>
     </parent>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>

--- a/agileboot-common/pom.xml
+++ b/agileboot-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agileboot</artifactId>
         <groupId>com.agileboot</groupId>
-        <version>1.0.0</version>
+        <version>${agileboot.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agileboot-domain/pom.xml
+++ b/agileboot-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agileboot</artifactId>
         <groupId>com.agileboot</groupId>
-        <version>1.0.0</version>
+        <version>${agileboot.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agileboot-infrastructure/pom.xml
+++ b/agileboot-infrastructure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agileboot</artifactId>
         <groupId>com.agileboot</groupId>
-        <version>1.0.0</version>
+        <version>${agileboot.version}</version>
     </parent>
     <packaging>jar</packaging>
     <modelVersion>4.0.0</modelVersion>
@@ -116,7 +116,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.1.1.RELEASE</version>
                 <configuration>
                     <fork>true</fork> <!-- 如果没有该配置，devtools不会生效 -->
                 </configuration>
@@ -131,7 +130,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.1.0</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <warName>${project.artifactId}</warName>

--- a/agileboot-integration-test/pom.xml
+++ b/agileboot-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agileboot</artifactId>
         <groupId>com.agileboot</groupId>
-        <version>1.0.0</version>
+        <version>${agileboot.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agileboot-orm/pom.xml
+++ b/agileboot-orm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agileboot</artifactId>
         <groupId>com.agileboot</groupId>
-        <version>1.0.0</version>
+        <version>${agileboot.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.agileboot</groupId>
     <artifactId>agileboot</artifactId>
-    <version>1.0.0</version>
+    <version>${agileboot.version}</version>
 
     <name>agileboot</name>
     <url>http://www.agileboot.vip</url>
@@ -42,6 +42,10 @@
         <org.lionsoul.version>2.6.5</org.lionsoul.version>
         <com.google.guava.version>31.0.1-jre</com.google.guava.version>
         <springdoc-openapi-ui.version>1.6.14</springdoc-openapi-ui.version>
+        <spring.boot.version>2.7.0</spring.boot.version>
+        <maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>
+        <maven.surefire.plugin.version>2.5</maven.surefire.plugin.version>
+        <maven.war.plugin.version>3.1.0</maven.war.plugin.version>
     </properties>
 
     <!-- 依赖声明 -->
@@ -52,7 +56,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.7.0</version>
+                <version>${spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -307,25 +311,49 @@
     </dependencies>
 
     <build>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compiler.plugin.version}</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                        <encoding>${project.build.sourceEncoding}</encoding>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven.surefire.plugin.version}</version>
+                    <!-- 想跑test的话  设置成false  -->
+                    <configuration>
+                        <skipTests>true</skipTests>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${maven.war.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring.boot.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
-                <!-- 想跑test的话  设置成false  -->
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
重构了项目的版本管理

1. 各个子模块的项目的父项目版本统一管理到根项目中
2. 项目依赖库和插件库的版本统一到Properties中管理
3. 插件的管理统一收集到根项目中
4. spring-boot-maven-plugin的版本保持和spring-boot的版本相同（为2.7.0）