### PR TITLE
修复Windows下如果有光驱（可能是虚拟光驱）分母（磁盘总容量）为0的异常

### DIFF
--- a/agileboot-domain/src/main/java/com/agileboot/domain/system/monitor/dto/ServerInfo.java
+++ b/agileboot-domain/src/main/java/com/agileboot/domain/system/monitor/dto/ServerInfo.java
@@ -143,7 +143,11 @@ public class ServerInfo {
             diskInfo.setTotal(convertFileSize(total));
             diskInfo.setFree(convertFileSize(free));
             diskInfo.setUsed(convertFileSize(used));
-            diskInfo.setUsage(NumberUtil.div(used * 100, total, 4));
+            if (total != 0){
+                diskInfo.setUsage(NumberUtil.div(used * 100, total, 4));
+            } else {
+                diskInfo.setUsage(0);//Windows下如果有光驱（可能是虚拟光驱），total为0，不能做除数
+            }
             diskInfos.add(diskInfo);
         }
     }


### PR DESCRIPTION
菜单“系统监控-->服务监控”出错：空的光驱磁盘总容量为0，计算磁盘使用率时总容量为分母，不能为零。