### PR TITLE
fix: 去除commons.validator依赖

### DIFF
--- a/agileboot-common/pom.xml
+++ b/agileboot-common/pom.xml
@@ -153,11 +153,6 @@
         </dependency>
 
         <dependency>
-            <groupId>commons-validator</groupId>
-            <artifactId>commons-validator</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
             <!-- 不排除掉slf4j的话 会冲突-->

--- a/agileboot-common/src/main/java/com/agileboot/common/utils/ip/IpUtil.java
+++ b/agileboot-common/src/main/java/com/agileboot/common/utils/ip/IpUtil.java
@@ -1,6 +1,6 @@
 package com.agileboot.common.utils.ip;
 
-import org.apache.commons.validator.routines.InetAddressValidator;
+import cn.hutool.core.lang.Validator;
 
 /**
  * ip校验器
@@ -8,14 +8,12 @@ import org.apache.commons.validator.routines.InetAddressValidator;
  */
 public class IpUtil {
 
-    private static final InetAddressValidator VALIDATOR = InetAddressValidator.getInstance();
-
     public static boolean isValidIpv4(String inetAddress) {
-        return VALIDATOR.isValidInet4Address(inetAddress);
+        return Validator.isIpv4(inetAddress);
     }
 
     public static boolean isValidIpv6(String inetAddress) {
-        return VALIDATOR.isValidInet6Address(inetAddress);
+        return Validator.isIpv6(inetAddress);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
         <mybatis-plus.version>3.5.2</mybatis-plus.version>
         <mybatis-plus-generator.version>3.5.1</mybatis-plus-generator.version>
         <mockito.version>1.10.19</mockito.version>
-        <common-validator.version>1.7</common-validator.version>
         <it.ozimov.version>0.7.3</it.ozimov.version>
         <io.swagger.version>1.6.8</io.swagger.version>
         <org.lionsoul.version>2.6.5</org.lionsoul.version>
@@ -214,12 +213,6 @@
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
                 <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>commons-validator</groupId>
-                <artifactId>commons-validator</artifactId>
-                <version>${common-validator.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Vulnerabilities from dependencies: [CVE-2020-15250](https://mvnrepository.com/artifact/commons-validator/commons-validator/1.7)