### PR TITLE
Update CustomExcelUtil.java

### DIFF
--- a/agileboot-common/src/main/java/com/agileboot/common/utils/poi/CustomExcelUtil.java
+++ b/agileboot-common/src/main/java/com/agileboot/common/utils/poi/CustomExcelUtil.java
@@ -47,7 +47,7 @@ public class CustomExcelUtil {
     public static <T> void writeToOutputStream(List<T> list, Class<T> clazz, OutputStream outputStream) {
 
         // 通过工具类创建writer
-        ExcelWriter writer = ExcelUtil.getWriter();
+        ExcelWriter writer = ExcelUtil.getWriter(true);
 
         ExcelSheet sheetAnno = clazz.getAnnotation(ExcelSheet.class);
 


### PR DESCRIPTION
ExcelUtil.getWriter()默认创建xls格式的Excel，因此写出到客户端也需要自定义文件名为XXX.xls，现在配套的前端代码中设置的文件扩展名为xlsx，导出后打开会出现文件损坏的提示。改为ExcelUtil.getWriter(true)后，可生成xlsx格式的文件。