### PR TITLE
fix:移除 selectMenuListByUserId 中无效的排序字段

### DIFF
--- a/agileboot-domain/src/main/java/com/agileboot/domain/system/menu/db/SysMenuMapper.java
+++ b/agileboot-domain/src/main/java/com/agileboot/domain/system/menu/db/SysMenuMapper.java
@@ -29,7 +29,7 @@ public interface SysMenuMapper extends BaseMapper<SysMenuEntity> {
         + "WHERE u.user_id = #{userId} "
         + " AND m.status = 1 "
         + " AND m.deleted = 0 "
-        + "ORDER BY m.parent_id, m.order_num")
+        + "ORDER BY m.parent_id")
     List<SysMenuEntity> selectMenuListByUserId(@Param("userId")Long userId);
 
 


### PR DESCRIPTION
通过 agileboot-20230814.sql 脚本创建的 sys_menu 表，已经移除了  order_num 字段。
但是 selectMenuListByUserId 仍然使用了 order_num 进行排序。
目前使用非 admin 账号登录的时候，就会触发这个 bug，包括演示服务器也存在这个问题。