### PR TITLE
fix: 修改“岗位管理”-全部导出-按钮功能错误：请求类型修改为get，请求路径修改为/excel，重新提供方法返回不分页的查询结果。

### DIFF
--- a/agileboot-admin/src/main/java/com/agileboot/admin/controller/system/SysPostController.java
+++ b/agileboot-admin/src/main/java/com/agileboot/admin/controller/system/SysPostController.java
@@ -1,8 +1,10 @@
 package com.agileboot.admin.controller.system;
 
+import com.agileboot.admin.customize.aop.accessLog.AccessLog;
 import com.agileboot.common.core.base.BaseController;
 import com.agileboot.common.core.dto.ResponseDTO;
 import com.agileboot.common.core.page.PageDTO;
+import com.agileboot.common.enums.common.BusinessTypeEnum;
 import com.agileboot.common.utils.poi.CustomExcelUtil;
 import com.agileboot.domain.common.command.BulkOperationCommand;
 import com.agileboot.domain.system.post.PostApplicationService;
@@ -10,8 +12,6 @@ import com.agileboot.domain.system.post.command.AddPostCommand;
 import com.agileboot.domain.system.post.command.UpdatePostCommand;
 import com.agileboot.domain.system.post.dto.PostDTO;
 import com.agileboot.domain.system.post.query.PostQuery;
-import com.agileboot.admin.customize.aop.accessLog.AccessLog;
-import com.agileboot.common.enums.common.BusinessTypeEnum;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -53,13 +53,20 @@ public class SysPostController extends BaseController {
         return ResponseDTO.ok(pageDTO);
     }
 
+    /**
+     *
+     * @param response http响应
+     * @param query 查询参数
+     * @author Kevin Zhang
+     * @date 2023-10-02
+     */
     @Operation(summary = "职位列表导出")
     @AccessLog(title = "岗位管理", businessType = BusinessTypeEnum.EXPORT)
     @PreAuthorize("@permission.has('system:post:export')")
-    @PostMapping("/export")
+    @GetMapping("/excel")
     public void export(HttpServletResponse response, PostQuery query) {
-        PageDTO<PostDTO> pageDTO = postApplicationService.getPostList(query);
-        CustomExcelUtil.writeToResponse(pageDTO.getRows(), PostDTO.class, response);
+        List<PostDTO> all = postApplicationService.getPostListAll(query);
+        CustomExcelUtil.writeToResponse(all, PostDTO.class, response);
     }
 
     /**

--- a/agileboot-admin/src/main/java/com/agileboot/admin/controller/system/SysPostController.java
+++ b/agileboot-admin/src/main/java/com/agileboot/admin/controller/system/SysPostController.java
@@ -54,7 +54,7 @@ public class SysPostController extends BaseController {
     }
 
     /**
-     *
+     * 导出查询到的所有岗位信息到excel文件
      * @param response http响应
      * @param query 查询参数
      * @author Kevin Zhang

--- a/agileboot-domain/src/main/java/com/agileboot/domain/system/post/PostApplicationService.java
+++ b/agileboot-domain/src/main/java/com/agileboot/domain/system/post/PostApplicationService.java
@@ -4,12 +4,12 @@ import com.agileboot.common.core.page.PageDTO;
 import com.agileboot.domain.common.command.BulkOperationCommand;
 import com.agileboot.domain.system.post.command.AddPostCommand;
 import com.agileboot.domain.system.post.command.UpdatePostCommand;
+import com.agileboot.domain.system.post.db.SysPostEntity;
+import com.agileboot.domain.system.post.db.SysPostService;
 import com.agileboot.domain.system.post.dto.PostDTO;
 import com.agileboot.domain.system.post.model.PostModel;
 import com.agileboot.domain.system.post.model.PostModelFactory;
 import com.agileboot.domain.system.post.query.PostQuery;
-import com.agileboot.domain.system.post.db.SysPostEntity;
-import com.agileboot.domain.system.post.db.SysPostService;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,6 +31,19 @@ public class PostApplicationService {
         Page<SysPostEntity> page = postService.page(query.toPage(), query.toQueryWrapper());
         List<PostDTO> records = page.getRecords().stream().map(PostDTO::new).collect(Collectors.toList());
         return new PageDTO<>(records, page.getTotal());
+    }
+
+    /**
+     * 查询满足条件的所有岗位，不分页
+     * @param query 查询条件
+     * @return 满足查询条件的岗位列表
+     * @author Kevin Zhang
+     * @date 2023-10-02
+     */
+    public List<PostDTO> getPostListAll(PostQuery query) {
+        List<SysPostEntity> all = postService.list(query.toQueryWrapper());
+        List<PostDTO> records = all.stream().map(PostDTO::new).collect(Collectors.toList());
+        return records;
     }
 
     public PostDTO getPostInfo(Long postId) {


### PR DESCRIPTION
1、controller中的请求类型和路径和前端代码对不上，做了对应修改；
2、并且导出全部应该是“页面上查询到的结果不分页的数据”，在service中添加了不分页的方法来修正该逻辑错误。