### PR TITLE
fix: 修改“岗位管理”-查询功能中的1-默认排序为数据库中的post_sort，2-设置漏掉的前端查询条件“创建时间”对应的字段cre…

### DIFF
--- a/agileboot-domain/src/main/java/com/agileboot/domain/system/post/PostApplicationService.java
+++ b/agileboot-domain/src/main/java/com/agileboot/domain/system/post/PostApplicationService.java
@@ -29,11 +29,6 @@ public class PostApplicationService {
     private final SysPostService postService;
 
     public PageDTO<PostDTO> getPostList(PostQuery query) {
-        // 当前端没有选择排序字段时，则使用post_sort字段排序，在AbstractQuery中默认为升序
-        if (StrUtil.isEmpty(query.getOrderColumn())) {
-            query.setOrderColumn("post_sort");
-        }
-        query.setTimeRangeColumn("create_time");
         Page<SysPostEntity> page = postService.page(query.toPage(), query.toQueryWrapper());
         List<PostDTO> records = page.getRecords().stream().map(PostDTO::new).collect(Collectors.toList());
         return new PageDTO<>(records, page.getTotal());

--- a/agileboot-domain/src/main/java/com/agileboot/domain/system/post/query/PostQuery.java
+++ b/agileboot-domain/src/main/java/com/agileboot/domain/system/post/query/PostQuery.java
@@ -24,6 +24,11 @@ public class PostQuery extends AbstractPageQuery<SysPostEntity> {
             .eq(status != null, "status", status)
             .eq(StrUtil.isNotEmpty(postCode), "post_code", postCode)
             .like(StrUtil.isNotEmpty(postName), "post_name", postName);
+        // 当前端没有选择排序字段时，则使用post_sort字段升序排序（在父类AbstractQuery中默认为升序）
+        if (StrUtil.isEmpty(this.getOrderColumn())) {
+            this.setOrderColumn("post_sort");
+        }
+        this.setTimeRangeColumn("create_time");
 
         return queryWrapper;
     }


### PR DESCRIPTION
1、当前端没有传递排序字段的时候，设置为post_sort字段；
2、前端传递过来的创建时间在PostQuery没有对应的TimeRangeColumn；
3、前端也做了对应的修改：包括表格列上的排序，当前有两个列支持排序，完善了查询、重置对表格列上排序的清除逻辑。